### PR TITLE
Support adapter build mode to preview2 adapter module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,6 +2994,7 @@ name = "wasi-preview1-component-adapter"
 version = "17.0.0"
 dependencies = [
  "byte-array-literals",
+ "cfg-if",
  "object",
  "wasi",
  "wasm-encoder",

--- a/crates/wasi-preview1-component-adapter/Cargo.toml
+++ b/crates/wasi-preview1-component-adapter/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 wasi = { version = "0.11.0", default-features = false }
 wit-bindgen = { workspace = true, default-features = false, features = ["macros"] }
 byte-array-literals = { workspace = true }
+cfg-if = "1.0.0"
 
 [build-dependencies]
 wasm-encoder = { workspace = true }
@@ -19,7 +20,7 @@ object = { workspace = true, default-features = false, features = ["archive"] }
 
 [lib]
 test = false
-crate-type = ["staticlib"]
+crate-type = ["staticlib", "cdylib"]
 name = "wasi_snapshot_preview1"
 
 [features]
@@ -27,3 +28,4 @@ default = ["reactor"]
 reactor = []
 command = []
 proxy = []
+adapter = []

--- a/crates/wasi-preview1-component-adapter/build.rs
+++ b/crates/wasi-preview1-component-adapter/build.rs
@@ -2,6 +2,10 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
+    // for adapter .wasm only
+    if std::env::var("CARGO_FEATURE_ADAPTER").is_err() {
+        return;
+    }
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
     let wasm = build_raw_intrinsics();


### PR DESCRIPTION
Add the "adapter" feature restoring dynamically linked .wasm module target. It is required by Rust WASM modules as they don't support linking to the static library.